### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ProductMadness/pm_internal_infrastructure  @ProductMadness/pm_internal_infrastructure_lead


### PR DESCRIPTION
Need to add a CODEOWNERS file to all infra repos with the following content:

* @ProductMadness/pm_internal_infrastructure  @ProductMadness/pm_internal_infrastructure_lead

It helps us with the notifications / policies / etc. https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners